### PR TITLE
Update sedrad version to 1.0.2

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -9,9 +9,9 @@ import (
 const validCharacters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
 
 const (
-	appMajor uint = 0
-	appMinor uint = 12
-	appPatch uint = 15
+	appMajor uint = 1
+	appMinor uint = 0
+	appPatch uint = 2
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
After installing version 1.0.2, `./sedrad --version` returns `sedrad version 0.12.15`.
`get_info` rpc method does the same thing which can be frustrating 